### PR TITLE
fix(Signature): fix event doc

### DIFF
--- a/docs/signature.md
+++ b/docs/signature.md
@@ -95,7 +95,7 @@ Una vez que el usuario completa el flujo:
     user_reference: "<user-reference>",
     signature_attempt_id: "sa_...",
     identity_id: "id_...",
-    signed_document_id: "sd_...",
+    signed_document_ids: ["sd_1...", ..., "sd_n..."],
   },
   created_at: "<created_at>"
 }


### PR DESCRIPTION
Se hace un fix a cómo se mostraban los `signed_document_ids` en los eventos del `signature_attempt`.