### PR TITLE
feat(Event): update validation successful event

### DIFF
--- a/docs/integration-guide/modules/disclosure.mdx
+++ b/docs/integration-guide/modules/disclosure.mdx
@@ -449,7 +449,6 @@ Además, siempre que se emita un evento `disclosure_request.granted`, también r
             payload: {
                 user_reference: "<user-reference>",
                 validation_attempt_id: "va_...",
-                identity_id: "id_..."
             },
             created_at: "<created_at>"
         }
@@ -595,4 +594,4 @@ Utiliza el `identity_id` para consultar la identidad creada por tu usuario desde
 
 ## Prueba tu integración
 
-Para probar tu integración, en ambiente de pruebas (Sandbox) puedes utilizar el parámetro `force_error` en el payload de la solicitud de disclosure, tanto en el backend como en el frontend. Por ejemplo, puedes simular una validación fallida pasando `force_error: "validation_error"`.
+Para probar tu integración, en ambiente de pruebas (Sandbox) puedes utilizar el parámetro `force_error` en el payload de la solicitud de disclosure, tanto en el backend como en el frontend. Por ejemplo, puedes simular una validación fallida pasando `force_error: "document_validation_error"`.


### PR DESCRIPTION
Se cambia actualiza el evento de `validation_attempt.successful`.

Ahora no viene la`identity_id`.