### PR TITLE
feat(docs): add codesandbox example of the full consent template

### DIFF
--- a/docs/integration-guide/modules/consent.mdx
+++ b/docs/integration-guide/modules/consent.mdx
@@ -35,6 +35,18 @@ El proceso de consentimiento embebido se compone de los siguientes pasos:
 3. Se genera un **token de acción** cada vez que el usuario haga click un checkbox de consentimiento.
 4. Al momento de persistir los datos del usuario, se envían los token de acción para crear un **registro de consentimientos** con evidencia del proceso.
 
+## Ejemplo de integración
+A continuación, te mostramos un ejemplo de integración del componente de consentimiento implementado en un formulario.
+
+<iframe src="https://codesandbox.io/embed/4pg3zp?view=preview"
+  style={{width: '100%', height: '640px', border: '0', borderRadius: '4px', overflow: 'hidden'}}
+  title="soyio-consent-sample"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+  referrerPolicy="no-referrer"
+></iframe>
+
+Puedes utilizar este ejemplo como base para integrar el componente en tu aplicación. Más adelante encontrarás una guía detallada para implementarlo desde cero.
 
 ## Configuración inicial
 


### PR DESCRIPTION
Se agrega el iframe del ejemplo del consent en Codesandbox a las docs.

https://github.com/user-attachments/assets/a063ffcd-dfa1-4fa1-abbf-3d293aa8130a

El diseño puede cambiar en demand en CSB, planeo afinarlo un poco